### PR TITLE
Added null check to avoid errors with passing null to a count parameter

### DIFF
--- a/library/Zend/Validate/File/Count.php
+++ b/library/Zend/Validate/File/Count.php
@@ -253,16 +253,16 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
         if (($file === null) || !empty($file['tmp_name'])) {
             $this->addFile($value);
         }
+	if (!$this->_files === null) {
+            $this->_count = count($this->_files);
+            if (($this->_max !== null) && ($this->_count > $this->_max)) {
+                return $this->_throw($file, self::TOO_MANY);
+            }
 
-        $this->_count = count($this->_files);
-        if (($this->_max !== null) && ($this->_count > $this->_max)) {
-            return $this->_throw($file, self::TOO_MANY);
+            if (($this->_min !== null) && ($this->_count < $this->_min)) {
+                return $this->_throw($file, self::TOO_FEW);
+            }
         }
-
-        if (($this->_min !== null) && ($this->_count < $this->_min)) {
-            return $this->_throw($file, self::TOO_FEW);
-        }
-
         return true;
     }
 

--- a/library/Zend/Validate/File/Count.php
+++ b/library/Zend/Validate/File/Count.php
@@ -253,15 +253,12 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
         if (($file === null) || !empty($file['tmp_name'])) {
             $this->addFile($value);
         }
-	if (!$this->_files === null) {
-            $this->_count = count($this->_files);
-            if (($this->_max !== null) && ($this->_count > $this->_max)) {
-                return $this->_throw($file, self::TOO_MANY);
-            }
-
-            if (($this->_min !== null) && ($this->_count < $this->_min)) {
-                return $this->_throw($file, self::TOO_FEW);
-            }
+        $this->_count = $this->_files !== null ? count($this->_files) : 0;
+        if (($this->_max !== null) && ($this->_count > $this->_max)) {
+            return $this->_throw($file, self::TOO_MANY);
+        }
+        if (($this->_min !== null) && ($this->_count < $this->_min)) {
+            return $this->_throw($file, self::TOO_FEW);
         }
         return true;
     }


### PR DESCRIPTION
We have ran into this when attempting to validate a form where the file is empty with LibreTime (and is allowed to be) see https://github.com/LibreTime/libretime/pull/707
This just checks to make sure the file variable is not null before passing it to count which as of 7.2 has tighter type checking.