### PR TITLE
composer: add ext-iconv dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
 	"license": "BSD-3-Clause",
 	"require": {
 		"php": ">=5.2.11",
+		"ext-ctype": "*",
 		"ext-iconv": "*",
+		"ext-reflection": "*",
 		"zf1s/zend-exception": "^1.12",
 		"zf1s/zend-loader": "^1.12",
 		"zf1s/zend-locale": "^1.12"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	"license": "BSD-3-Clause",
 	"require": {
 		"php": ">=5.2.11",
+		"ext-iconv": "*",
 		"zf1s/zend-exception": "^1.12",
 		"zf1s/zend-loader": "^1.12",
 		"zf1s/zend-locale": "^1.12"


### PR DESCRIPTION
Call to undefined function iconv_strlen() in vendor/zf1s/zend-validate/library/Zend/Validate/Hostname.php on line 1823

this also adds `ext-ctype` and `ext-reflection`:
- https://github.com/pld-linux/ZendFramework/blob/auto/th/ZendFramework-1.12.20-1/ZendFramework.spec#L1623-L1624

i've once went over ZF1 readme and filled the ext deps in that ZendFramework package:
- https://github.com/pld-linux/ZendFramework/commit/a61792aa4de46796d08413c9e5767a368c482ad9